### PR TITLE
[TLOZ] Add FileNotFoundError handling for TLOZ base rom

### DIFF
--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -77,6 +77,12 @@ class TLoZWorld(World):
         self.levels = None
         self.filler_items = None
 
+    @classmethod
+    def stage_assert_generate(cls, multiworld: MultiWorld):
+        rom_file = get_base_rom_path()
+        if not os.path.exists(rom_file):
+            raise FileNotFoundError(rom_file)
+
     def create_item(self, name: str):
         return TLoZItem(name, item_table[name].classification, self.item_name_to_id[name], self.player)
 


### PR DESCRIPTION
## What is this fixing or adding?
Adding proper handling for not detecting the base rom for TLOZ (i.e. whoever is running things forgot to put their base rom into the folder)

## How was this tested?
Ran both a local generate and a webhost instance with the base rom missing. Saw the correct error message.